### PR TITLE
fix: artifact upload needs clone

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
         id: release
         with:
           release-type: simple
+      - name: Clone Repo
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/checkout@v4
       - name: Download artifacts
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Fixes:
```
  gh release upload v1.1.0 build-*
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```